### PR TITLE
Add Shotlingo + new ASO subsection under Marketing & Growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ Gather tools that can help you market your product effectively and grow your aud
 | [Sensor Tower](https://sensortower.com/)          | App store analytics and insights. | Free / Per feature |
 | [Google Trends](https://trends.google.com/trends) | Search analytics and insights.    | Free               |
 
+### App Store Optimization (ASO)
+
+| Tool                                     | Description                                                                                                          | Pricing           |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| [Shotlingo](https://shotlingo.com)       | AI-powered App Store & Google Play screenshot localization to 40+ languages. Handles text expansion, RTL, and fonts. | Free / $15/month  |
+| [AppLaunchpad](https://theapplaunchpad.com/) | App screenshot maker with pre-designed templates and device frames.                                               | Free / Paid tiers |
+
 ### Launch and Community Platforms
 
 | Tool                                                                             | Description                                                             |


### PR DESCRIPTION
Adding Shotlingo to a new **App Store Optimization (ASO)** subsection under Marketing & Growth.

**Why a new subsection:** ASO is a distinct discipline within app marketing. The existing Idea Validation subsection has Sensor Tower (an ASO analytics tool), but there's no dedicated ASO section for creative tools. Added AppLaunchpad alongside Shotlingo since it's the closest existing tool in the space.

**About Shotlingo:** Web-based tool that localizes App Store and Google Play screenshots to 40+ languages with AI. Handles text expansion per language, RTL mirroring (Arabic, Hebrew, Persian, Urdu), and platform-appropriate fonts. Free tier available, $15/mo Pro.

**Website:** https://shotlingo.com

Happy to relocate Shotlingo under an existing subsection (e.g. SEO Tools or Design & UI) if you prefer to keep the structure flat.